### PR TITLE
Added Unix Compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ unsigned char payload[] = {
 
 ## Changelog
 
-- `README.md`: Reorganized structure; added Prerequisites, Installation, Features, Tradecraft & MITRE Mapping, and License sections; fixed command hyphens for consistent copy-paste; updated Usage and Generating Shellcode examples.
+- `README.md`: Reorganized structure; added Prerequisites, Installation, Features, Tradecraft & MITRE Mapping sections; fixed command hyphens for consistent copy-paste; updated Usage and Generating Shellcode examples.
 - Added full definitions for `X64_NOPS` and `X86_NOPS` in `NOPe.py` to resolve the NameError and enable dual-architecture/OS (Windows/Unix) support.
 - Annotated `NOPe.py` and `bin2sc.py` with in-code comments mapping to red team tradecraft (obfuscation, execution, staging) and MITRE ATT&CK techniques.
 - Introduced file-level headers in both scripts clarifying purpose and tradecraft context.

--- a/README.md
+++ b/README.md
@@ -1,79 +1,94 @@
 # NOPe
 
-A quick and hacky script to test alternatives to traditional NOP sleds by prepending various x86 or x64 "NOP-like" instructions to shellcode and executing it in memory.
+A flexible payload execution toolkit that prepends randomized NOP sleds to shellcode for obfuscation and executes it in memory.
 
-Note: You must use the correct architecture of Python for the type of shellcode you're testing.
+> **Tradecraft Note:** Demonstrates NOP sled obfuscation (MITRE ATT&CK T1027) and in-memory shellcode execution (T1059) to bypass static and dynamic defenses.
 
-- Use 32-bit Python for x86 shellcode
-- Use 64-bit Python for x64 shellcode
+## Prerequisites
+
+- Python 3.6 or higher
+- 32-bit Python interpreter for x86 payloads
+- 64-bit Python interpreter for x64 payloads
+
+## Installation
+
+```bash
+git clone https://github.com/cyberchancer/NOPe.git
+cd NOPe
+python3 -m venv venv
+source venv/bin/activate
+```
+
+*(No external dependencies; uses standard `ctypes`, `mmap`, and `argparse`.)*
+
+## Features
+
+- Dual-architecture support: x86 and x64 shellcode
+- Randomized NOP sled variants to evade static analysis (T1027)
+- In-memory shellcode execution to minimize disk artifacts (T1059)
+- Listing and selection of NOP variants for tailored payload crafting
+
+## Tradecraft & MITRE Mapping
+
+| Technique ID | Technique Name                    | Description                                          |
+|--------------|-----------------------------------|------------------------------------------------------|
+| T1027        | Obfuscated Files or Information   | Prepends randomized NOP-like instructions to payload |
+| T1059        | Command and Scripting Interpreter | Executes payloads in memory without dropping files   |
 
 ## Usage
 
-Run with the default payload (x64 message box shellcode):
-```
-python NOPe.py
-```
+```bash
+# Default payload (x64 message box)
+python3 NOPe.py
 
-Run with your own shellcode binary:
-```
-python NOPe.py -f my_shellcode.bin
-```
+# Custom shellcode
+python3 NOPe.py -f my_shellcode.bin
 
-Specify architecture:
-```
-python NOPe.py -f msgbox.x86.bin –arch x86
-```
+# Specify architecture
+python3 NOPe.py -f payload.bin --arch x86
 
-Enable verbose output:
-```
-python NOPe.py -f msgbox.x64.bin –arch x64 –verbose
-```
+# Verbose mode
+python3 NOPe.py -f payload.bin --arch x64 --verbose
 
-List supported NOP variants for a given architecture:
-```
-python NOPe.py –arch x86 –list-nops
+# List available NOP variants
+python3 NOPe.py --arch x86 --list-nops
 ```
 
 ## Generating Shellcode
 
-To regenerate the message box payloads using `MSFVenom`:
+Use MSFVenom to create sample payloads:
 
-x64 shellcode
-```
+```bash
+# x64 messagebox
 msfvenom -p windows/x64/messagebox TEXT="NOPe64" TITLE="Hello" -f raw > msgbox.x64.bin
+
+# x86 messagebox
+msfvenom -p windows/messagebox   TEXT="NOPe32" TITLE="Hello" -f raw > msgbox.x86.bin
 ```
 
-x86 shellcode
-```
-msfvenom -p windows/messagebox TEXT="NOPe32" TITLE="Hello" -f raw > msgbox.x86.bin
-```
+---
 
 # bin2sc
 
-A simple script for converting raw `.bin` shellcode files into formatted C or Rust source code.
+A helper script to convert raw shellcode binaries into source-code snippets.
+
+> **Tradecraft Note:** Facilitates payload embedding and staging for diverse delivery mechanisms (T1105, T1027).
 
 ## Usage
 
-Convert and print shellcode in C-style hex array format:
-```
-python bin2sc.py shellcode.bin
-```
-Write the output to a file:
+```bash
+# Print C array
+python3 bin2sc.py shellcode.bin
 
-```
-python bin2sc.py shellcode.bin -o output.h
-```
+# Write to file
+python3 bin2sc.py shellcode.bin -o output.h
 
-Change output format:
+# Select style: c-string or rust
+python3 bin2sc.py shellcode.bin -s c-string
+python3 bin2sc.py shellcode.bin -s rust
 
-```
-python bin2sc.py shellcode.bin -s c-array      # Default
-python bin2sc.py shellcode.bin -s c-string     # “\x90\x90…” style
-python bin2sc.py shellcode.bin -s rust         # Rust-style byte array
-```
-Customise the variable name and bytes per line:
-```
-python bin2sc.py shellcode.bin –name my_shellcode –bytes-per-line 8
+# Customize variable name and bytes per line
+python3 bin2sc.py shellcode.bin --name mypayload --bytes-per-line 8
 ```
 
 ## Example Output (C Array)
@@ -83,3 +98,10 @@ unsigned char payload[] = {
     0x90, 0x90, 0xCC, 0xCC, 0xEB, 0xFE
 };
 ```
+
+## Changelog
+
+- `README.md`: Reorganized structure; added Prerequisites, Installation, Features, Tradecraft & MITRE Mapping, and License sections; fixed command hyphens for consistent copy-paste; updated Usage and Generating Shellcode examples.
+- Added full definitions for `X64_NOPS` and `X86_NOPS` in `NOPe.py` to resolve the NameError and enable dual-architecture/OS (Windows/Unix) support.
+- Annotated `NOPe.py` and `bin2sc.py` with in-code comments mapping to red team tradecraft (obfuscation, execution, staging) and MITRE ATT&CK techniques.
+- Introduced file-level headers in both scripts clarifying purpose and tradecraft context.

--- a/bin2sc.py
+++ b/bin2sc.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
+# File: bin2sc.py
+# Purpose: Convert raw shellcode .bin files into embeddable source-code snippets (C arrays, C strings, Rust).
+# Red Team Tradecraft: Automates payload embedding and staging, facilitating in-memory execution and obfuscation (T1027, T1105).
 import sys
 import os
 import argparse
 
 
+# Function: read_shellcode_file
+# Description: Reads raw binary shellcode from disk, handling errors to ensure payload accessibility.
 def read_shellcode_file(filepath: str) -> bytes:
     """Read binary shellcode file."""
     try:
@@ -14,6 +19,8 @@ def read_shellcode_file(filepath: str) -> bytes:
         sys.exit(1)
 
 
+# Function: format_shellcode
+# Description: Transforms raw shellcode bytes into the specified source-code format (C array, C string, Rust).
 def format_shellcode(shellcode: bytes, style: str, name: str, bytes_per_line: int) -> str:
     """Format shellcode bytes in the selected output style."""
     if style == "c-array":
@@ -41,6 +48,8 @@ def format_shellcode(shellcode: bytes, style: str, name: str, bytes_per_line: in
         sys.exit(1)
 
 
+# Function: write_to_file
+# Description: Writes formatted shellcode content to the specified file, with error handling for reliability.
 def write_to_file(output_path: str, content: str) -> None:
     """Write formatted shellcode to a file."""
     try:
@@ -52,6 +61,8 @@ def write_to_file(output_path: str, content: str) -> None:
         sys.exit(1)
 
 
+# Function: main
+# Description: Parses command-line arguments and orchestrates conversion of shellcode to source-code formats.
 def main():
     parser = argparse.ArgumentParser(
         description="Convert a raw shellcode .bin file to various source-code formats.",


### PR DESCRIPTION
- `README.md`: Reorganized structure; added Prerequisites, Installation, Features, Tradecraft & MITRE Mapping sections; fixed command hyphens for consistent copy-paste; updated Usage and Generating Shellcode examples.
- Added full definitions for `X64_NOPS` and `X86_NOPS` in `NOPe.py` to resolve the NameError and enable dual-architecture/OS (Windows/Unix) support.
- Annotated `NOPe.py` and `bin2sc.py` with in-code comments mapping to red team tradecraft (obfuscation, execution, staging) and MITRE ATT&CK techniques.
- Introduced file-level headers in both scripts clarifying purpose and tradecraft context.